### PR TITLE
fix(error_middleware): better detection of JSON Content-Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* fix(error_middleware): better detection of JSON Content-Type
 * Bump github.com/gofrs/uuid from 4.1.0+incompatible to 4.2.0+incompatible
 
 ## v1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To be Released
 
 * fix(error_middleware): better detection of JSON Content-Type
+* fix(error_middleware): do not write a body if it has already been written
 * Bump github.com/gofrs/uuid from 4.1.0+incompatible to 4.2.0+incompatible
 
 ## v1.4.1

--- a/error_middleware.go
+++ b/error_middleware.go
@@ -68,6 +68,11 @@ func writeError(log logrus.FieldLogger, w negroni.ResponseWriter, err error) {
 		w.WriteHeader(500)
 	}
 
+	// If the body has already been partially written, do not write anything else
+	if w.Size() != 0 {
+		return
+	}
+
 	if isContentTypeJSON(w.Header().Get("Content-Type")) {
 		if isCauseValidationErrors {
 			json.NewEncoder(w).Encode(errors.RootCause(err))

--- a/error_middleware.go
+++ b/error_middleware.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
@@ -67,7 +68,7 @@ func writeError(log logrus.FieldLogger, w negroni.ResponseWriter, err error) {
 		w.WriteHeader(500)
 	}
 
-	if w.Header().Get("Content-Type") == "application/json" {
+	if isContentTypeJSON(w.Header().Get("Content-Type")) {
 		if isCauseValidationErrors {
 			json.NewEncoder(w).Encode(errors.RootCause(err))
 		} else {
@@ -76,4 +77,13 @@ func writeError(log logrus.FieldLogger, w negroni.ResponseWriter, err error) {
 	} else {
 		fmt.Fprintln(w, err)
 	}
+}
+
+// isContentTypeJSON returns true if the given string is a valid JSON value for the HTTP Content-Type header. Various values can be used to state that a payload is a JSON:
+// - The RFC 4627 defines the Content-Type "application/json" (https://datatracker.ietf.org/doc/html/rfc4627)
+// - The RFC 6839 defines the suffix "+json":
+//     The suffix "+json" MAY be used with any media type whose representation follows that established for "application/json"
+//     (https://datatracker.ietf.org/doc/html/rfc6839#page-4)
+func isContentTypeJSON(contentType string) bool {
+	return contentType == "application/json" || strings.HasSuffix(contentType, "+json")
 }

--- a/error_middleware_test.go
+++ b/error_middleware_test.go
@@ -65,6 +65,18 @@ func TestErrorMiddlware(t *testing.T) {
 			statusCode:   500,
 			expectedBody: "{\"error\":\"wrapping: error\"}\n",
 		},
+		"it should add the Content-Type plain text if none is specified": {
+			handlerFunc: func(w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+				log := logger.Get(r.Context()).WithField("field", "value")
+				return errorutils.Wrapf(logger.ToCtx(context.Background(), log), errors.New("error"), "wrapping")
+			},
+			assertLogs: func(t *testing.T, hook *pkgtest.Hook) {
+				require.Equal(t, 1, len(hook.Entries))
+				assert.Equal(t, "value", hook.Entries[0].Data["field"])
+			},
+			statusCode:   500,
+			expectedBody: "wrapping: error\n",
+		},
 	}
 
 	for msg, test := range tests {

--- a/error_middleware_test.go
+++ b/error_middleware_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,11 +20,11 @@ import (
 
 func TestErrorMiddlware(t *testing.T) {
 	tests := map[string]struct {
-		contentType  string
-		handlerFunc  HandlerFunc
-		assertLogs   func(*testing.T, *pkgtest.Hook)
-		statusCode   int
-		expectedBody string
+		contentType        string
+		handlerFunc        HandlerFunc
+		assertLogs         func(*testing.T, *pkgtest.Hook)
+		expectedStatusCode int
+		expectedBody       string
 	}{
 		"it should set the status code to 500 if there is none": {
 			contentType: "application/json",
@@ -35,8 +36,8 @@ func TestErrorMiddlware(t *testing.T) {
 				require.Equal(t, 1, len(hook.Entries))
 				assert.Equal(t, "value", hook.Entries[0].Data["field"])
 			},
-			statusCode:   500,
-			expectedBody: "{\"error\":\"wrapping: error\"}\n",
+			expectedStatusCode: 500,
+			expectedBody:       "{\"error\":\"wrapping: error\"}\n",
 		},
 		"it should set the status code to 422 if this is a ValidationErrors": {
 			contentType: "application/json",
@@ -49,8 +50,8 @@ func TestErrorMiddlware(t *testing.T) {
 
 				return pkgerrors.Wrap(err, "biniou")
 			},
-			statusCode:   422,
-			expectedBody: "{\"errors\":{\"test\":[\"biniou\"]}}\n",
+			expectedStatusCode: 422,
+			expectedBody:       "{\"errors\":{\"test\":[\"biniou\"]}}\n",
 		},
 		"it should detect any Content-Type ending with +json as JSON": {
 			contentType: "application/vnd.docker.plugins.v1.1+json",
@@ -62,8 +63,8 @@ func TestErrorMiddlware(t *testing.T) {
 				require.Equal(t, 1, len(hook.Entries))
 				assert.Equal(t, "value", hook.Entries[0].Data["field"])
 			},
-			statusCode:   500,
-			expectedBody: "{\"error\":\"wrapping: error\"}\n",
+			expectedStatusCode: 500,
+			expectedBody:       "{\"error\":\"wrapping: error\"}\n",
 		},
 		"it should add the Content-Type plain text if none is specified": {
 			handlerFunc: func(w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -74,8 +75,18 @@ func TestErrorMiddlware(t *testing.T) {
 				require.Equal(t, 1, len(hook.Entries))
 				assert.Equal(t, "value", hook.Entries[0].Data["field"])
 			},
-			statusCode:   500,
-			expectedBody: "wrapping: error\n",
+			expectedStatusCode: 500,
+			expectedBody:       "wrapping: error\n",
+		},
+		"it should not write anything in the body if it has already been written": {
+			handlerFunc: func(w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+				w.WriteHeader(500)
+				// My handler writes something in the body but returns an error
+				fmt.Fprintln(w, "biniou")
+				return errors.New("my error")
+			},
+			expectedStatusCode: 500,
+			expectedBody:       "biniou\n",
 		},
 	}
 
@@ -98,7 +109,7 @@ func TestErrorMiddlware(t *testing.T) {
 			if test.assertLogs != nil {
 				test.assertLogs(t, hook)
 			}
-			assert.Equal(t, test.statusCode, w.Code)
+			assert.Equal(t, test.expectedStatusCode, w.Code)
 			assert.Equal(t, test.expectedBody, w.Body.String())
 		})
 	}


### PR DESCRIPTION
I also updated the error middleware to **not** write the body in case it has already been written in the handler


Fix #36


- [x] Add a changelog entry in the `CHANGELOG.md` file, in the "To be Released" section.
- [x] As much as possible, do not deprecate parameters. Only add new parameters.