### PR TITLE
feat(error_middleware): log at info level for all non-5xx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* feat(error_middleware): log at info level for all non-5xx errors
 * chore(deps): bump github.com/gofrs/uuid from 4.2.0+incompatible to 4.3.0+incompatible
 * chore(deps): bump github.com/Scalingo/go-utils/logger
 * chore(deps): bump github.com/sirupsen/logrus from 1.8.1 to 1.9.0

--- a/error_middleware.go
+++ b/error_middleware.go
@@ -92,8 +92,8 @@ func writeError(log logrus.FieldLogger, w negroni.ResponseWriter, err error) {
 }
 
 // isContentTypeJSON returns true if the given string is a valid JSON value for the HTTP Content-Type header. Various values can be used to state that a payload is a JSON:
-// - The RFC 4627 defines the Content-Type "application/json" (https://datatracker.ietf.org/doc/html/rfc4627)
-// - The RFC 6839 defines the suffix "+json":
+//   - The RFC 4627 defines the Content-Type "application/json" (https://datatracker.ietf.org/doc/html/rfc4627)
+//   - The RFC 6839 defines the suffix "+json":
 //     The suffix "+json" MAY be used with any media type whose representation follows that established for "application/json"
 //     (https://datatracker.ietf.org/doc/html/rfc6839#page-4)
 func isContentTypeJSON(contentType string) bool {

--- a/error_middleware.go
+++ b/error_middleware.go
@@ -43,7 +43,7 @@ var ErrorMiddleware = MiddlewareFunc(func(handler HandlerFunc) HandlerFunc {
 		}
 
 		if err != nil {
-			log = log.WithField("error", err)
+			log = log.WithError(err)
 			writeError(log, rw, err)
 		}
 


### PR DESCRIPTION
I'll probably do a release of the version 1.4.5 if it's OK for you.

Fix #47

- [x] Add a changelog entry in the `CHANGELOG.md` file, in the "To be Released" section.
- [x] As much as possible, do not deprecate parameters. Only add new parameters.