### PR TITLE
build(go.mod): update `github.com/urfave/negroni` from v1 to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be Released
 
+* build(go.mod): update github.com/urfave/negroni from v1 to v3
+
 ## v1.8.2
 
 * feat(middleware): add a middleware to set the `Content-Type` to `application/json`

--- a/error_middleware.go
+++ b/error_middleware.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/negroni/v2"
+	"github.com/urfave/negroni/v3"
 
 	"github.com/Scalingo/go-utils/errors/v2"
 	"github.com/Scalingo/go-utils/logger"

--- a/error_middleware.go
+++ b/error_middleware.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v2"
 
 	"github.com/Scalingo/go-utils/errors/v2"
 	"github.com/Scalingo/go-utils/logger"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
-	github.com/urfave/negroni v1.0.0
+	github.com/urfave/negroni/v2 v2.0.2
 	gopkg.in/errgo.v1 v1.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-handlers
 
-go 1.22.9
+go 1.22.10
 
 require (
 	github.com/Scalingo/go-utils/errors/v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/negroni/v3 v3.1.1
-	gopkg.in/errgo.v1 v1.0.1
 )
 
 require (
@@ -20,5 +19,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.27.0 // indirect
+	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
-	github.com/urfave/negroni/v2 v2.0.2
+	github.com/urfave/negroni/v3 v3.1.1
 	gopkg.in/errgo.v1 v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/urfave/negroni/v2 v2.0.2 h1:27gJcVxYJ2a/ytEoCHoJ7ybvyhymV4cAhGuMxkyCsrU=
-github.com/urfave/negroni/v2 v2.0.2/go.mod h1:SjdApKzYrObukpN/NnlejbQiZWIUjfDFzQltScGYigI=
+github.com/urfave/negroni/v3 v3.1.1 h1:6MS4nG9Jk/UuCACaUlNXCbiKa0ywF9LXz5dGu09v8hw=
+github.com/urfave/negroni/v3 v3.1.1/go.mod h1:jWvnX03kcSjDBl/ShB0iHvx5uOs7mAzZXW+JvJ5XYAs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
-github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+github.com/urfave/negroni/v2 v2.0.2 h1:27gJcVxYJ2a/ytEoCHoJ7ybvyhymV4cAhGuMxkyCsrU=
+github.com/urfave/negroni/v2 v2.0.2/go.mod h1:SjdApKzYrObukpN/NnlejbQiZWIUjfDFzQltScGYigI=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/logging_middleware.go
+++ b/logging_middleware.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v2"
 )
 
 var (

--- a/logging_middleware.go
+++ b/logging_middleware.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/negroni/v2"
+	"github.com/urfave/negroni/v3"
 )
 
 var (

--- a/profiling_router.go
+++ b/profiling_router.go
@@ -7,8 +7,7 @@ import (
 	"os"
 	"strconv"
 
-	"gopkg.in/errgo.v1"
-
+	"github.com/Scalingo/go-utils/errors/v2"
 	"github.com/Scalingo/go-utils/logger"
 )
 
@@ -29,9 +28,9 @@ func NewProfilingRouter(ctx context.Context) (*Router, error) {
 
 	prof := new(profiling)
 
-	err := prof.initialize()
+	err := prof.initialize(ctx)
 	if err != nil {
-		return nil, errgo.Notef(err, "fail to initialize pprof profiling")
+		return nil, errors.Wrap(ctx, err, "initialize pprof profiling")
 	}
 
 	if !prof.isActivable() {
@@ -64,7 +63,7 @@ func NewProfilingRouter(ctx context.Context) (*Router, error) {
 	return r, nil
 }
 
-func (prof *profiling) initialize() error {
+func (prof *profiling) initialize(ctx context.Context) error {
 	pprofEnable := os.Getenv("PPROF_ENABLED")
 	if pprofEnable == "" {
 		return nil
@@ -73,7 +72,7 @@ func (prof *profiling) initialize() error {
 	var err error
 	prof.enable, err = strconv.ParseBool(pprofEnable)
 	if err != nil {
-		return errgo.Notef(err, "fail to parse environment variable PPROF_ENABLED")
+		return errors.Wrap(ctx, err, "parse environment variable PPROF_ENABLED")
 	}
 	prof.auth.username = os.Getenv("PPROF_USERNAME")
 	prof.auth.password = os.Getenv("PPROF_PASSWORD")


### PR DESCRIPTION
Fix #92

Negroni is only used to call `negroni.NewResponseWriter`. The changelog (https://github.com/urfave/negroni/blob/master/CHANGELOG.md) does not mention anything about this.

- [x] Add a changelog entry in the `CHANGELOG.md` file, in the "To be Released" section.
- [x] As much as possible, do not deprecate parameters. Only add new parameters.