### PR TITLE
fix(go) Do not require go 1.24.3 when go 1.24 is enough in libs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-handlers
 
-go 1.24.3
+go 1.24
 
 require (
 	github.com/Scalingo/go-utils/errors/v2 v2.5.1


### PR DESCRIPTION
- [x] Add a changelog entry in the `CHANGELOG.md` file, in the "To be Released" section.
- [ ] As much as possible, do not deprecate parameters. Only add new parameters.

It fixes a regression introduced in this release cycle that's why there's no other changelog entries